### PR TITLE
Fix XPC `sendDREF`/`sendDREFs` for array-valued datarefs

### DIFF
--- a/src/xpc3.py
+++ b/src/xpc3.py
@@ -305,7 +305,7 @@ class XPlaneConnect(object):
                 if len(value) > 255:
                     raise ValueError("value must have less than 256 items.")
                 fmt = "<B{0:d}sB{1:d}f".format(len(dref), len(value))
-                buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), len(value), value)
+                buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), len(value), *value)
             else:
                 fmt = "<B{0:d}sBf".format(len(dref))
                 buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), 1, value)


### PR DESCRIPTION
See https://github.com/nasa/XPlaneConnect/pull/242 and https://github.com/nasa/XPlaneConnect/issues/198 for details.